### PR TITLE
Update Path.ShortLongConversions.cs

### DIFF
--- a/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
+++ b/AlphaFS/Filesystem/Path Class/Path.ShortLongConversions.cs
@@ -117,7 +117,7 @@ namespace Alphaleonis.Win32.Filesystem
       [SecurityCritical]
       public static bool IsLongPath(string path)
       {
-         return !Utils.IsNullOrWhiteSpace(path) && path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase);
+         return !Utils.IsNullOrWhiteSpace(path) && path.StartsWith(LongPathPrefix, StringComparison.Ordinal);
       }
 
       #endregion // IsLongPath
@@ -145,11 +145,11 @@ namespace Alphaleonis.Win32.Filesystem
 
          // ".", "C:"
          if (path.Length <= 2 ||
-             path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase) ||
-             path.StartsWith(LogicalDrivePrefix, StringComparison.OrdinalIgnoreCase))
+             path.StartsWith(LongPathPrefix, StringComparison.Ordinal) ||
+             path.StartsWith(LogicalDrivePrefix, StringComparison.Ordinal))
             return path;
 
-         if (path.StartsWith(UncPrefix, StringComparison.OrdinalIgnoreCase))
+         if (path.StartsWith(UncPrefix, StringComparison.Ordinal))
             return LongPathUncPrefix + path.Substring(UncPrefix.Length);
 
          // Don't use char.IsLetter() here as that can be misleading.
@@ -229,7 +229,7 @@ namespace Alphaleonis.Win32.Filesystem
          if (options != GetFullPathOptions.None)
             path = ApplyFullPathOptions(path, options);
 
-         return !path.StartsWith(LongPathPrefix, StringComparison.OrdinalIgnoreCase)
+         return !path.StartsWith(LongPathPrefix, StringComparison.Ordinal)
             ? path
             : (path.StartsWith(LongPathUncPrefix, StringComparison.OrdinalIgnoreCase)
                ? UncPrefix + path.Substring(LongPathUncPrefix.Length)


### PR DESCRIPTION
Changed the string comparison from OrdinalIgnoreCase to Ordinal where it is not neccessary because there are no letters within the prefix (LongPathPrefix, LogicalDrivePrefix and UncPrefix - but LongPathUncPrefix remains OrdinalIgnoreCase).

Benefit: Better performance
Loss: If the constant values changes (e.g. because of "#if" compiler directives for compilation on a non-Windows system, there is a slight chance that those systems use a letter where windows uses only punctuations and then the tests would fail) 
